### PR TITLE
Fixing image resizer size validator

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -37,11 +37,11 @@ func (v *Validator) CheckHostInWhiteList(requestUrl string) error {
 
 // Validates if new request size is valid or not
 func (v *Validator) CheckRequestNewSize(s *Size) error {
-	if s.Height >= v.config.SizeLimits.Height {
+	if s.Height > v.config.SizeLimits.Height {
 		return error(fmt.Errorf("Height cannot be higher than %d", v.config.SizeLimits.Height))
 	}
 
-	if s.Width >= v.config.SizeLimits.Width ||  s.Height >= v.config.SizeLimits.Height {
+	if s.Width > v.config.SizeLimits.Width ||  s.Height >= v.config.SizeLimits.Height {
 		return error(fmt.Errorf("Width cannot be higher than %d", v.config.SizeLimits.Width))
 	}
 


### PR DESCRIPTION
even though max size was set to 3000, 
requesting a 3000 width or height image would return an error, 
this seems to be caused by a slight logic error on the validator
i think i fixed it :)